### PR TITLE
Updated to include examples showing use of storyOptions and decorators

### DIFF
--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -3,7 +3,7 @@ import { configure, storiesOf } from '@storybook/vue'
 import { action, configureActions } from '@storybook/addon-actions';
 import { registerStories } from 'vue-storybook'
 import { withNotes } from "@storybook/addon-notes";
-import { withKnobs, text, color, select, boolean } from "@storybook/addon-knobs/vue";
+import { withKnobs, text, boolean, number, select, color, radios, date, files, object, array, optionsKnob, button } from "@storybook/addon-knobs/vue";
 import StoryTemplateDecorator from '../../src/stories/story-template-decorator';
 import { withInfo } from 'storybook-addon-vue-info'
 // const req = require.context('../../src/stories', true, /.stories.js$/)
@@ -15,12 +15,21 @@ function loadStories() {
       req, 
       filename, 
       storiesOf, 
-      knobs: {
+      plugins: {
         withKnobs,
         withNotes,
-        action,
         text,
-        boolean
+        boolean,
+        number,
+        select,
+        color,
+        radios,
+        date,
+        files,
+        object,
+        array,
+        optionsKnob,
+        button
       },
       decorators: [
         withInfo,

--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -10,10 +10,10 @@ import { withInfo } from 'storybook-addon-vue-info'
 const req = require.context("../../src/components", true, /\.vue$/);
 
 function loadStories() {
-  req.keys().forEach(filename => {
+  req.keys().forEach(fileName => {
     let configurationObject = {
       req, 
-      filename, 
+      fileName, 
       storiesOf, 
       plugins: {
         withKnobs,

--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -1,20 +1,46 @@
 /* eslint-disable */
-import { configure, storiesOf } from '@storybook/vue'
-import { action, configureActions } from '@storybook/addon-actions';
-import { registerStories } from 'vue-storybook'
-import { withNotes } from "@storybook/addon-notes";
-import { withKnobs, text, boolean, number, select, color, radios, date, files, object, array, optionsKnob, button } from "@storybook/addon-knobs/vue";
+import {
+  configure,
+  storiesOf
+} from '@storybook/vue';
+import {
+  action,
+  configureActions
+} from '@storybook/addon-actions';
+import {
+  registerStories
+} from 'vue-storybook';
+import {
+  withNotes
+} from "@storybook/addon-notes";
+import {
+  withKnobs,
+  text,
+  boolean,
+  number,
+  select,
+  color,
+  radios,
+  date,
+  files,
+  object,
+  array,
+  optionsKnob,
+  button
+} from "@storybook/addon-knobs/vue";
 import StoryTemplateDecorator from '../../src/stories/story-template-decorator';
-import { withInfo } from 'storybook-addon-vue-info'
+import {
+  withInfo
+} from 'storybook-addon-vue-info'
 // const req = require.context('../../src/stories', true, /.stories.js$/)
 const req = require.context("../../src/components", true, /\.vue$/);
 
 function loadStories() {
   req.keys().forEach(fileName => {
     let configurationObject = {
-      req, 
-      fileName, 
-      storiesOf, 
+      req,
+      fileName,
+      storiesOf,
       plugins: {
         withKnobs,
         withNotes,
@@ -33,7 +59,7 @@ function loadStories() {
       },
       decorators: [
         withInfo,
-        StoryTemplateDecorator  
+        StoryTemplateDecorator
       ],
       storyOptions: {
         info: true
@@ -42,6 +68,6 @@ function loadStories() {
 
     registerStories(configurationObject)
   })
-}
+};
 
 configure(loadStories, module)

--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -4,19 +4,34 @@ import { action, configureActions } from '@storybook/addon-actions';
 import { registerStories } from 'vue-storybook'
 import { withNotes } from "@storybook/addon-notes";
 import { withKnobs, text, color, select, boolean } from "@storybook/addon-knobs/vue";
-
+import StoryTemplateDecorator from '../../src/stories/story-template-decorator';
+import { withInfo } from 'storybook-addon-vue-info'
 // const req = require.context('../../src/stories', true, /.stories.js$/)
 const req = require.context("../../src/components", true, /\.vue$/);
 
 function loadStories() {
   req.keys().forEach(filename => {
-    registerStories(req, filename, storiesOf, {
-      withKnobs,
-      withNotes,
-      action,
-      text,
-      boolean
-    })
+    let configurationObject = {
+      req, 
+      filename, 
+      storiesOf, 
+      knobs: {
+        withKnobs,
+        withNotes,
+        action,
+        text,
+        boolean
+      },
+      decorators: [
+        withInfo,
+        StoryTemplateDecorator  
+      ],
+      storyOptions: {
+        info: true
+      }
+    }
+
+    registerStories(configurationObject)
   })
 }
 

--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -31,7 +31,7 @@ import {
 import StoryTemplateDecorator from '../../src/stories/story-template-decorator';
 import {
   withInfo
-} from 'storybook-addon-vue-info'
+} from 'storybook-addon-vue-info';
 // const req = require.context('../../src/stories', true, /.stories.js$/)
 const req = require.context("../../src/components", true, /\.vue$/);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",
+    "storybook-addon-vue-info": "^1.0.1",
     "vue-cli-plugin-storybook": "^0.6.1",
     "vue-template-compiler": "^2.5.21",
     "vue-storybook": "^1.0.0-0"

--- a/src/stories/story-template-decorator.js
+++ b/src/stories/story-template-decorator.js
@@ -1,0 +1,18 @@
+function StoryTemplate(context, story) {
+   return {
+      props: {
+         header: {
+            type: String,
+            default: 'No Story Header Provided'
+         }
+      },
+      template: ` <div id="story-container">
+                     <div class="row">
+                        <h1 class="twelve columns">${story.story}</h1>
+                     </div>
+                     <div class="story-content"><story/></div>
+                  </div>`
+   }
+}
+
+export default StoryTemplate;


### PR DESCRIPTION
Short example showing the use of the decorators and storyOptions arguments.

Example shows the use of how someone might want to implement a consistent wrapper around their components for things like headers and other common elements between stories